### PR TITLE
피드 좋아요 기능 구현

### DIFF
--- a/Infrastructure/persistence/feed_like_repository.py
+++ b/Infrastructure/persistence/feed_like_repository.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+from sqlmodel import Session, select, func
+
+from domain.model.feed.feed_like import FeedLike
+from domain.repository.feed_like_interface import IFeedLikeRepository
+
+
+class FeedLikeRepository(IFeedLikeRepository):
+    def __init__(self, db: Session):
+        self.db = db
+
+    def save(self, feed_like: FeedLike) -> FeedLike:
+        self.db.add(feed_like)
+        self.db.commit()
+        self.db.refresh(feed_like)
+        return feed_like
+
+    def delete(self, feed_like: FeedLike):
+        self.db.delete(feed_like)
+        self.db.commit()
+
+    def find_by_feed_id_and_member_id(self, feed_id: int, member_id: int) -> Optional[FeedLike]:
+        statement = select(FeedLike).where(FeedLike.feed_id == feed_id, FeedLike.member_id == member_id)
+        return self.db.exec(statement).first()
+
+    def exists_by_feed_id_and_member_id(self, feed_id: int, member_id: int) -> bool:
+        statement = select(FeedLike.id).where(FeedLike.feed_id == feed_id,FeedLike.member_id == member_id)
+        result = self.db.exec(statement).first() is not None
+        return result
+
+    def count_by_feed_id(self, feed_id: int) -> int:
+        statement = select(func.count()).select_from(FeedLike).where(FeedLike.feed_id == feed_id)
+        result = self.db.exec(statement).scalar_one()
+        return result

--- a/application/service/feed_like.py
+++ b/application/service/feed_like.py
@@ -1,0 +1,33 @@
+from application.service.member import MemberService
+from core.exception.error_message import ErrorMessage
+from domain.model.feed.feed_like import FeedLike
+from domain.repository.feed_like_interface import IFeedLikeRepository
+
+
+class FeedLikeService:
+    def __init__(self, feed_like_repository: IFeedLikeRepository, member_service: MemberService):
+        self.feed_like_repository = feed_like_repository
+        self.member_service = member_service
+
+    def like(self, feed_id: int, member_id: int) -> FeedLike:
+        self.member_service.find_by_id(member_id)
+        if self.exists_by_feed_id_and_member_id(feed_id, member_id):
+            raise ValueError(ErrorMessage.FEED_LIKE_ALREADY_EXISTS.value)
+        feed_like = FeedLike.create(feed_id=feed_id, member_id=member_id)
+        return self.feed_like_repository.save(feed_like)
+
+    def unlike(self, feed_id: int, member_id: int):
+        feed_like = self.find_by_feed_id_and_member_id(feed_id, member_id)
+        return self.feed_like_repository.delete(feed_like)
+
+    def find_by_feed_id_and_member_id(self, feed_id: int, member_id: int) -> FeedLike:
+        feed_like = self.feed_like_repository.find_by_feed_id_and_member_id(feed_id, member_id)
+        if feed_like is None:
+            raise ValueError(ErrorMessage.FEED_LIKE_NOT_FOUND.value)
+        return feed_like
+
+    def exists_by_feed_id_and_member_id(self, feed_id: int, member_id: int) -> bool:
+        return self.feed_like_repository.exists_by_feed_id_and_member_id(feed_id, member_id)
+
+    def count(self, feed_id: int) -> int:
+        return self.feed_like_repository.count_by_feed_id(feed_id)

--- a/core/dependencies/feed_like.py
+++ b/core/dependencies/feed_like.py
@@ -1,0 +1,18 @@
+from fastapi import Depends
+
+from Infrastructure.config.database import get_session
+from Infrastructure.persistence.feed_like_repository import FeedLikeRepository
+from application.service.feed_like import FeedLikeService
+from core.dependencies.member import get_member_service
+from domain.repository.feed_like_interface import IFeedLikeRepository
+
+
+def get_feed_like_repository(session=Depends(get_session)) -> IFeedLikeRepository:
+    return FeedLikeRepository(session)
+
+
+def get_feed_like_service(
+        feed_like_repository: IFeedLikeRepository = Depends(get_feed_like_repository),
+        member_service=Depends(get_member_service)
+) -> FeedLikeService:
+    return FeedLikeService(feed_like_repository, member_service)

--- a/domain/model/feed/feed_like.py
+++ b/domain/model/feed/feed_like.py
@@ -1,0 +1,39 @@
+from typing import Optional
+from datetime import datetime, timezone, timedelta
+
+from sqlmodel import SQLModel, Field, UniqueConstraint
+
+
+class FeedLike(SQLModel, table=True):
+    """
+    Feed Like 테이블 모델
+
+    Author: 신효승
+    Created: 2025-05-25
+
+    Description:
+    - feed_likes 테이블은 피드에 대한 회원의 좋아요 기록을 저장합니다.
+    - 하나의 회원이 같은 피드에 중복으로 좋아요를 남길 수 없도록 feed_id, member_id에 유니크 제약조건이 있습니다.
+
+    Field Description:
+    - id: 고유 식별자 (AutoIncrement)
+    - feed_id: 피드 ID (ForeignKey, feeds.id)
+    - member_id: 회원 ID (ForeignKey, members.id)
+    - created_at: 생성 시각 (KST, 기본값: 현재 시간)
+    """
+    __tablename__ = "feed_likes"
+    __table_args__ = (
+        UniqueConstraint("feed_id", "member_id", name="uq_feed_member"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    feed_id: int = Field(nullable=False, foreign_key="feeds.id")
+    member_id: int = Field(nullable=False, foreign_key="members.id")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc) + timedelta(hours=9))
+
+    @classmethod
+    def create(cls, feed_id: int, member_id: int) -> "FeedLike":
+        return cls(
+            feed_id=feed_id,
+            member_id=member_id,
+        )

--- a/domain/repository/feed_like_interface.py
+++ b/domain/repository/feed_like_interface.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from domain.model.feed.feed_like import FeedLike
+
+
+class IFeedLikeRepository(ABC):
+    @abstractmethod
+    def save(self, feed_like: FeedLike) -> FeedLike:
+        pass
+
+    @abstractmethod
+    def delete(self, feed_like_id: int):
+        pass
+
+    @abstractmethod
+    def find_by_feed_id_and_member_id(self, feed_id: int, member_id: int) -> Optional[FeedLike]:
+        pass
+
+    @abstractmethod
+    def exists_by_feed_id_and_member_id(self, feed_id: int, member_id: int) -> bool:
+        pass
+
+    @abstractmethod
+    def count_by_feed_id(self, feed_id: int) -> int:
+        pass

--- a/http/feed_like.http
+++ b/http/feed_like.http
@@ -1,0 +1,17 @@
+### [POST] 피드 좋아요 등록
+POST http://localhost:8000/feed/like/1?member_id=1
+
+###
+
+### [POST] 피드 좋아요 등록 (이미 좋아요 누른 경우, 에러 확인)
+POST http://localhost:8000/feed/like/1?member_id=1
+
+###
+
+### [DELETE] 피드 좋아요 취소
+DELETE http://localhost:8000/feed/like/1?member_id=1
+
+###
+
+### [DELETE] 피드 좋아요 취소 (좋아요 정보 없음, 에러 확인)
+DELETE http://localhost:8000/feed/like/1?member_id=1

--- a/web/route/feed_likes.py
+++ b/web/route/feed_likes.py
@@ -1,0 +1,132 @@
+from fastapi import APIRouter, Depends, status, Query
+
+from core.dependencies.feed_like import get_feed_like_service
+from core.exception.error_message import ErrorMessage
+from web.payload.response.base_response import BaseResponse
+
+feed_like_router = APIRouter(prefix="/feed/like", tags=["FeedLike"])
+
+
+@feed_like_router.post(
+    "/{feed_id}",
+    summary="피드 좋아요 등록 API",
+    status_code=status.HTTP_201_CREATED,
+    response_model=BaseResponse,
+    responses={
+        201: {
+            "description": "피드 좋아요 성공",
+            "content": {
+                "application/json": {
+                    "schema": BaseResponse.schema(),
+                    "example": {
+                        "message": "좋아요 성공"
+                    }
+                }
+            }
+        },
+        400: {
+            "description": "좋아요 등록 실패 (이미 좋아요 또는 회원 없음)",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "error": {"type": "string"}
+                        }
+                    },
+                    "examples": {
+                        "user_not_found": {
+                            "value": {
+                                "error": ErrorMessage.MEMBER_NOT_FOUND.value
+                            }
+                        },
+                        "already_exists": {
+                            "value": {
+                                "error": ErrorMessage.FEED_LIKE_ALREADY_EXISTS.value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    description="""
+    피드 좋아요 등록 API
+
+    - 설명: 피드에 좋아요를 등록합니다.
+    - 경로 파라미터
+      - feed_id: 좋아요할 피드 ID
+    - 쿼리 파라미터
+      - member_id: 좋아요를 누르는 회원 ID
+    - 응답
+      - 201: 좋아요 성공
+      - 400: 이미 좋아요를 누른 경우, 회원이 존재하지 않는 경우
+    """
+)
+def register(
+        feed_id: int,
+        member_id: int = Query(..., description="좋아요를 누르는 회원 ID"),
+        feed_like_service=Depends(get_feed_like_service)
+) -> BaseResponse:
+    feed_like_service.like(feed_id, member_id)
+    return BaseResponse(message="좋아요 성공")
+
+
+@feed_like_router.delete(
+    "/{feed_id}",
+    summary="피드 좋아요 취소 API",
+    status_code=status.HTTP_200_OK,
+    response_model=BaseResponse,
+    responses={
+        200: {
+            "description": "피드 좋아요 취소 성공",
+            "content": {
+                "application/json": {
+                    "schema": BaseResponse.schema(),
+                    "example": {
+                        "message": "좋아요 취소 성공"
+                    }
+                }
+            }
+        },
+        400: {
+            "description": "좋아요 취소 실패 (좋아요 정보 없음)",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "error": {"type": "string"}
+                        }
+                    },
+                    "examples": {
+                        "not_found": {
+                            "value": {
+                                "error": ErrorMessage.FEED_LIKE_NOT_FOUND.value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    description="""
+    피드 좋아요 취소 API
+
+    - 설명: 피드의 좋아요를 취소합니다.
+    - 경로 파라미터
+      - feed_id: 좋아요를 취소할 피드 ID
+    - 쿼리 파라미터
+      - member_id: 좋아요를 취소하는 회원 ID
+    - 응답
+      - 200: 좋아요 취소 성공
+      - 400: 좋아요 정보가 없는 경우
+    """
+)
+def remove(
+        feed_id: int,
+        member_id: int = Query(..., description="좋아요를 취소하는 회원 ID"),
+        feed_like_service=Depends(get_feed_like_service)
+) -> BaseResponse:
+    feed_like_service.unlike(feed_id, member_id)
+    return BaseResponse(message="좋아요 취소 성공")


### PR DESCRIPTION
## 개요
회원이 피드에 좋아요를 등록하고 취소할 수 있는 FeedLike(피드 좋아요) 기능을  
도메인 모델, 리포지토리, 서비스, FastAPI 엔드포인트, DI 설정, 테스트 예시, Swagger 문서화까지  
전반적으로 설계 및 구현하였습니다.


## 주요 변경 사항

- `FeedLike` 엔티티 모델 및 feed_id, member_id 유니크 제약조건 구현
- 피드 좋아요 리포지토리 추상화(`IFeedLikeRepository`) 및 SQLModel 기반 구현체(`FeedLikeRepository`) 작성
- 좋아요 등록, 취소, 단건 조회, 존재여부 확인, 카운트 등 비즈니스 로직을 담당하는 `FeedLikeService` 구현
- FastAPI 기반 좋아요 등록/취소 API 엔드포인트 구현
- 각 엔드포인트별 Swagger(OpenAPI) 문서화(summary, description, responses 등) 작성
- FeedLikeService, FeedLikeRepository 등 DI 함수 구현
- FeedLike API 테스트용 HTTP 요청 예시 파일(.http) 추가


## 테스트 및 검증

- Swagger UI에서 FeedLike API 엔드포인트 정상 동작 확인
- HTTP 예시 파일로 좋아요 등록/취소 및 에러 상황 테스트 완료
- 에러 및 예외처리, 에러 메시지 일관성 검증


## 참고 및 유의사항

- 피드 좋아요 기능의 모든 계층(모델, 리포지토리, 서비스, API)은 책임 분리 원칙에 따라 구현
- 모든 엔드포인트는 Swagger(OpenAPI) 문서화가 적용됨
- 유니크 제약조건 위반 등 예외 상황은 명확하게 처리


## 관련 이슈 및 마일스톤
- [피드 좋아요 기능 설계/구현] #7
- 마일스톤: 피드 좋아요 기능 개발